### PR TITLE
Return empty json object for blank markdown

### DIFF
--- a/lib/lemon_docs.rb
+++ b/lib/lemon_docs.rb
@@ -54,6 +54,6 @@ module LemonDocs
 
   def self.json_output(result)
     result = result.get_pointer(0)
-    JSON.parse(result.null? ? nil : result.read_string)
+    JSON.parse(result.null? ? '{}' : result.read_string)
   end
 end


### PR DESCRIPTION
JSON.parse(nil) raises error, lets return {} instead of this