### PR TITLE
Issue 4.ilya.validation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ rake lemon_docs:compile
 Convert API Blueprint files to JSON.
 ```
 require 'lemon_docs'
-LemonDocs.parse('# API doc')
+LemonDocs.parse('# API doc', strict: true, show_output: true)
 ```
+LemonDocs#parse also accepts named params 'strict' and 'show_output', enabled by default. If strict mode is disabled, warnings are ignored.
+
 Or via rake task. Generated files will be placed under doc/lemon_pages.
 ```
 rake lemon_docs:generate_json[path/to/folder]

--- a/lemon_docs.gemspec
+++ b/lemon_docs.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'ffi', '~> 1.9'
   s.add_dependency 'rake', '~> 11.3'
   s.add_dependency 'bundler', '~> 1.8'
-  s.add_dependency 'pry'
 end

--- a/lemon_docs.gemspec
+++ b/lemon_docs.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'ffi', '~> 1.9'
   s.add_dependency 'rake', '~> 11.3'
   s.add_dependency 'bundler', '~> 1.8'
+  s.add_dependency 'pry'
 end

--- a/lemon_docs.gemspec
+++ b/lemon_docs.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'ffi', '~> 1.9'
   s.add_dependency 'rake', '~> 11.3'
   s.add_dependency 'bundler', '~> 1.8'
+  s.add_dependency 'redcarpet'
 end

--- a/lib/lemon_docs/validator.rb
+++ b/lib/lemon_docs/validator.rb
@@ -1,0 +1,31 @@
+module LemonDocs
+  module Validator
+    def self.validate!(json, strict: true, show_output: true)
+      errors = find_errors([], json['content'])
+      notable_errors = strict ? errors : errors.select {|error| error[:kind] == 'ERROR' }
+
+      if show_output
+        notable_errors.each do |error|
+          puts "#{error[:kind].upcase}: #{error[:message]}"
+        end
+      end
+      return !notable_errors.any?
+    end
+
+    def self.find_errors(errors, node)
+      if node.is_a?(Array)
+        node.each { |sub_node| find_errors(errors, sub_node) }
+      elsif node.is_a?(Hash)
+        if node['element'] == 'annotation'
+          kind = node['meta']['classes'].first
+          message = node['content']
+          errors << {
+            kind: kind,
+            message: message
+          }
+        end
+      end
+      errors
+    end
+  end
+end

--- a/lib/lemon_docs/validator.rb
+++ b/lib/lemon_docs/validator.rb
@@ -2,7 +2,7 @@ module LemonDocs
   module Validator
     def self.validate!(json, strict: true, show_output: true)
       errors = find_errors([], json['content'])
-      notable_errors = strict ? errors : errors.select {|error| error[:kind] == 'ERROR' }
+      notable_errors = strict ? errors : errors.select {|error| error[:kind] == 'error' }
 
       if show_output
         notable_errors.each do |error|


### PR DESCRIPTION
Fixes #4 

LemonDocs::Validator.validate! can work in normal and strict (by default) modes. When strict mode is disabled all warnings are ignored, only errors count.
 